### PR TITLE
Make nature of height constraint more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ override func viewDidLoad() {
     self.keyboardFrameTrackerView.delegate = self
     self.inputTextView.inputAccessoryView = self.keyboardFrameTrackerView
     self.keyboardFrameTrackerView.translatesAutoresizingMaskIntoConstraints = false
-    self.keyboardFrameTrackerViewHeightConstraint = self.keyboardFrameTrackerView.heightAnchor.constraint(equalTo: self.inputTextView.heightAnchor, multiplier: 0)
+    self.keyboardFrameTrackerViewHeightConstraint = self.keyboardFrameTrackerView.heightAnchor.constraint(equalTo: self.inputTextView.heightAnchor, multiplier: 1)
     self.keyboardFrameTrackerViewHeightConstraint.isActive = true
 }
 ```

--- a/README.md
+++ b/README.md
@@ -44,19 +44,18 @@ override func viewDidLayoutSubviews() {
 }
 ```
 
-or you can use layout constraints 
+or you can use layout constraints. You can't constrain directly because an input accessory view does not share a view hierarchy with the rest of the window, but you can update the constant in ```viewDidLayoutSubviews```.
 ```swift
+var keyboardFrameTrackerViewHeightConstraint: NSLayoutConstraint!
 override func viewDidLoad() {
     super.viewDidLoad()
     self.keyboardFrameTrackerView.delegate = self
     self.inputTextView.inputAccessoryView = self.keyboardFrameTrackerView
     self.keyboardFrameTrackerView.translatesAutoresizingMaskIntoConstraints = false
-    self.keyboardFrameTrackerView.heightAnchor.constraint(equalTo: self.inputTextView.heightAnchor, multiplier: 1).isActive = true
+    self.keyboardFrameTrackerViewHeightConstraint = self.keyboardFrameTrackerView.heightAnchor.constraint(equalToConstant: 0)
+    self.keyboardFrameTrackerViewHeightConstraint.isActive = true
 }
-```
 
-then you you can update the constant in ```viewDidLayoutSubviews```
-```swift
 override func viewDidLayoutSubviews() {
      super.viewDidLayoutSubviews()
      self.keyboardFrameTrackerViewHeightConstraint.constant = self.inputTextView.frame.height

--- a/README.md
+++ b/README.md
@@ -46,14 +46,12 @@ override func viewDidLayoutSubviews() {
 
 or you can use layout constraints 
 ```swift
-var keyboardFrameTrackerViewHeightConstraint: NSLayoutConstraint!
 override func viewDidLoad() {
     super.viewDidLoad()
     self.keyboardFrameTrackerView.delegate = self
     self.inputTextView.inputAccessoryView = self.keyboardFrameTrackerView
     self.keyboardFrameTrackerView.translatesAutoresizingMaskIntoConstraints = false
-    self.keyboardFrameTrackerViewHeightConstraint = self.keyboardFrameTrackerView.heightAnchor.constraint(equalTo: self.inputTextView.heightAnchor, multiplier: 1)
-    self.keyboardFrameTrackerViewHeightConstraint.isActive = true
+    self.keyboardFrameTrackerView.heightAnchor.constraint(equalTo: self.inputTextView.heightAnchor, multiplier: 1).isActive = true
 }
 ```
 


### PR DESCRIPTION
If the multiplier is zero, you're not really constraining to the other anchor, you're just using the constant.

Using a multiplier of anything other than 0 causes it to crash because they do not share an ancestor.